### PR TITLE
fix(deps): use scoped eslint-comments plugin for ESLint 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint": "^10.0.0",
     "eslint-compat-utils": "^0.6.4",
     "eslint-config-prettier": "^10.1.1",
-    "eslint-plugin-eslint-comments": "^3.2.0",
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.7.0",
     "eslint-plugin-eslint-plugin": "^7.0.0",
     "eslint-plugin-jsdoc": "^64.0.0",
     "eslint-plugin-json-schema-validator": "^6.0.0",


### PR DESCRIPTION
Replace the unscoped `eslint-plugin-eslint-comments` dependency with its scoped successor. The 3.x scoped package fails during lint configuration because `@ota-meshi/eslint-plugin` requires at least 4.3.0.

Use `^4.7.0` because 4.7.0 is the first release that supports ESLint 10, while still satisfying `@ota-meshi/eslint-plugin`'s `^4.3.0` peer range.
